### PR TITLE
Support for v1beta1 PluginInterface GetDevicePluginOptions

### DIFF
--- a/pkg/dpm/plugin.go
+++ b/pkg/dpm/plugin.go
@@ -139,10 +139,18 @@ func (dpi *devicePlugin) register() error {
 	}
 	client := pluginapi.NewRegistrationClient(conn)
 	glog.Infof("%s: Registration for endpoint %s", dpi.Name, path.Base(dpi.Socket))
+
+	options, err := dpi.DevicePluginImpl.GetDevicePluginOptions(context.Background(), &pluginapi.Empty{})
+	if err != nil {
+		glog.Errorf("%s: Failed to get device plugin options %s", dpi.Name, err)
+		return err
+	}
+
 	reqt := &pluginapi.RegisterRequest{
 		Version:      pluginapi.Version,
 		Endpoint:     path.Base(dpi.Socket),
 		ResourceName: dpi.ResourceName,
+		Options:      options,
 	}
 
 	_, err = client.Register(context.Background(), reqt)


### PR DESCRIPTION
Request should be registered with options obtained from GetDevicePluginOptions. this allows you to specify PreStartRequired:true and other options from your device plugin

[root@mysystem]# oc logs pod/mypod | grep GetDev
I0715 12:53:48.737962       1 main.go:104] GetDevicePluginOptions
I0715 12:53:48.738040       1 main.go:104] GetDevicePluginOptions
I0715 12:53:48.738086       1 main.go:104] GetDevicePluginOptions
[root@mysystem]# oc logs pod/mypod | grep PreSt
I0715 12:54:03.380576       1 main.go:139] PreStartContainer: mydevice1
I0715 12:54:03.380863       1 main.go:139] PreStartContainer: mydevice2
I0715 12:54:03.381066       1 main.go:139] PreStartContainer: mydevice3
