### PR TITLE
Revert "Fix registration order k8s 1.25"

### DIFF
--- a/pkg/dpm/manager_test.go
+++ b/pkg/dpm/manager_test.go
@@ -73,8 +73,10 @@ var _ = Describe("DPM", func() {
 
 	BeforeEach(func() {
 		callsToStart = 0
-		plugins = append(plugins, "hello", "world")
-		manager = dpm.NewManager(FakeLister{Plugins: plugins})
+		plugins = append(plugins, "hello")
+		plugins = append(plugins, "world")
+		lister := FakeLister{Plugins: plugins}
+		manager = dpm.NewManager(lister)
 	})
 	Describe("When DPM start", func() {
 		Context("With lister containing multiple plugins", func() {

--- a/pkg/dpm/plugin.go
+++ b/pkg/dpm/plugin.go
@@ -74,16 +74,18 @@ func (dpi *devicePlugin) StartServer() error {
 		return nil
 	}
 
-	if err := dpi.register(); err != nil {
-		glog.Errorf("error registering with device plugin manager: %v", err)
-		return err
-	}
 	err := dpi.serve()
 	if err != nil {
 		return err
 	}
 
 	dpi.Running = true
+
+	err = dpi.register()
+	if err != nil {
+		dpi.StopServer()
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
Reverts kubevirt/device-plugin-manager#19

Seems I've messed this up before, and the registration order was correct. 

**Must** ensure we can get the device plugin correctly registered on K8S 1.25 before merging this.
