### PR TITLE
Revert k8s 1.25 registration order

### DIFF
--- a/pkg/dpm/manager_test.go
+++ b/pkg/dpm/manager_test.go
@@ -73,8 +73,10 @@ var _ = Describe("DPM", func() {
 
 	BeforeEach(func() {
 		callsToStart = 0
-		plugins = append(plugins, "hello", "world")
-		manager = dpm.NewManager(FakeLister{Plugins: plugins})
+		plugins = append(plugins, "hello")
+		plugins = append(plugins, "world")
+		lister := FakeLister{Plugins: plugins}
+		manager = dpm.NewManager(lister)
 	})
 	Describe("When DPM start", func() {
 		Context("With lister containing multiple plugins", func() {

--- a/pkg/dpm/plugin.go
+++ b/pkg/dpm/plugin.go
@@ -79,13 +79,12 @@ func (dpi *devicePlugin) StartServer() error {
 		return err
 	}
 
-	dpi.Running = true
-
 	err = dpi.register()
 	if err != nil {
 		dpi.StopServer()
 		return err
 	}
+	dpi.Running = true
 
 	return nil
 }

--- a/pkg/dpm/plugin.go
+++ b/pkg/dpm/plugin.go
@@ -74,16 +74,18 @@ func (dpi *devicePlugin) StartServer() error {
 		return nil
 	}
 
-	if err := dpi.register(); err != nil {
-		glog.Errorf("error registering with device plugin manager: %v", err)
-		return err
-	}
 	err := dpi.serve()
 	if err != nil {
 		return err
 	}
 
 	dpi.Running = true
+
+	err = dpi.register()
+	if err != nil {
+		dpi.StopServer()
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
The correct registration order is:
- serve
- register the plugin

It was correct in the first place.
