### PR TITLE
Update doc.go with correct repo link

### DIFF
--- a/pkg/dpm/doc.go
+++ b/pkg/dpm/doc.go
@@ -13,5 +13,5 @@
 // See Also
 //
 // Repository of this package and some plugins using it can be found on
-// https://github.com/kubevirt/kubernetes-device-plugins/.
+// https://github.com/kubevirt/device-plugin-manager/.
 package dpm


### PR DESCRIPTION
Changed the link from the archived repo to the current repo.